### PR TITLE
refactor(ui): migrate inline q-btn usage to reusable AppButton component

### DIFF
--- a/src/components/AppButton.vue
+++ b/src/components/AppButton.vue
@@ -1,0 +1,28 @@
+<template>
+  <q-btn
+    v-bind="$attrs"
+    :label="label"
+    :loading="isLoading"
+    :type="type"
+    color="primary"
+    outline
+    class="q-ma-sm"
+    @click="onClick"
+  />
+</template>
+
+<script lang="ts" setup>
+defineProps<{
+  label?: string;
+  isLoading?: boolean;
+  type?: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'click', evt: Event, go?: () => void): void;
+}>();
+
+function onClick(evt: Event, go?: () => void) {
+  emit('click', evt, go);
+}
+</script>

--- a/src/components/FormPix.vue
+++ b/src/components/FormPix.vue
@@ -38,21 +38,14 @@
       label="City"
       :rules="[(val) => !!val || 'City is required']"
     />
-
-    <q-btn
-      label="Generate"
-      :loading="isSubmitting"
-      type="submit"
-      color="primary"
-      outline
-      class="q-ma-sm"
-    />
+    <AppButton label="Generate" :loading="isSubmitting" type="subimit" />
   </q-form>
 </template>
 
 <script setup lang="ts">
 import { ref, watch } from 'vue';
 import { generatePix, isValidPixKey } from 'src/utils/pix';
+import AppButton from 'src/components/AppButton.vue';
 const emit = defineEmits<{
   (e: 'qr-generated', payload: string): void;
 }>();

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -29,13 +29,7 @@
             <q-icon name="qr_code" size="260px" class="qr_placeholder" />
           </div>
         </div>
-        <q-btn
-          outline
-          v-if="state.qrImage && !state.isLoad"
-          label="Download"
-          color="primary"
-          @click="downloadQrCode"
-        />
+        <AppButton v-if="state.qrImage && !state.isLoad" label="Download" @click="downloadQrCode" />
       </div>
     </div>
   </q-page>
@@ -45,6 +39,7 @@
 import { reactive } from 'vue';
 import { generateQrCode } from 'src/utils/qrcode';
 import FormPix from 'src/components/FormPix.vue';
+import AppButton from 'src/components/AppButton.vue';
 
 const state = reactive({
   qrImage: null as string | null,


### PR DESCRIPTION
*This commit introduces a new reusable component named `AppButton` that wraps the Quasar `<q-btn>` and supports `label`, `loading`, `type`, and emits the `click` event with full typing.

*All direct usages of `<q-btn>` with consistent configuration (e.g., outline, primary color, loading state) have been migrated to use `AppButton`, improving code reuse, consistency, and maintainability across the codebase.